### PR TITLE
Fix drei dependency bug by updating drei version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,83 +1,44 @@
 {
   "name": "vintage_turntable",
-
   "version": "0.1.0",
-
   "private": true,
-
   "homepage": ".",
-
   "dependencies": {
-
     "@react-spring/three": "^9.5.5",
-    "@react-three/drei": "^9.40.0",
-
+    "@react-three/drei": "^9.84.3",
     "@react-three/fiber": "^8.9.1",
-
     "@testing-library/jest-dom": "^5.16.5",
-
     "@testing-library/react": "^13.4.0",
-
     "@testing-library/user-event": "^13.5.0",
-
     "react": "^18.2.0",
-
     "react-dom": "^18.2.0",
-
     "react-scripts": "5.0.1",
-
     "three": "^0.146.0",
-
     "web-vitals": "^2.1.4",
-
     "zustand": "^4.2.0"
-
   },
-
   "scripts": {
-
     "start": "react-scripts start",
-
     "build": "react-scripts build",
-
     "test": "react-scripts test",
-
     "eject": "react-scripts eject"
-
   },
-
   "eslintConfig": {
-
     "extends": [
-
       "react-app",
-
       "react-app/jest"
-
     ]
-
   },
-
   "browserslist": {
-
     "production": [
-
       ">0.2%",
-
       "not dead",
-
       "not op_mini all"
-
     ],
-
     "development": [
-
       "last 1 chrome version",
-
       "last 1 firefox version",
-
       "last 1 safari version"
-
     ]
   },
   "devDependencies": {
@@ -88,6 +49,4 @@
     "@types/three": "^0.147.1",
     "typescript": "^4.9.4"
   }
-
 }
-

--- a/frontend/src/components/environment/Camera.tsx
+++ b/frontend/src/components/environment/Camera.tsx
@@ -17,8 +17,6 @@ export default function Camera({
   const [enableLookAt, setEnableLookAt] = useState(true);
 
   const { camera, mouse } = useThree();
-  
-  const ref = useRef();
 
   const vec = new THREE.Vector3();
 
@@ -71,7 +69,6 @@ export default function Camera({
   return (
     <>
       <AnimatedPerspectiveCamera
-        ref={ref}
         makeDefault
         fov={50}
         // See https://github.com/pmndrs/react-spring/issues/1302#issuecomment-1404664605


### PR DESCRIPTION
- Update @react-three/drei to 9.84.3 to fix dependency bug.
- Removed unused `useRef` from `Camera.tsx`.